### PR TITLE
Simplify dependency management using Beam BOM

### DIFF
--- a/Java/pom.xml
+++ b/Java/pom.xml
@@ -30,13 +30,10 @@
     <beam.version>2.47.0</beam.version>
 
     <bigquery.version>v2-rev20200719-1.30.10</bigquery.version>
-    <google-api-client.version>1.31.4</google-api-client.version>
-    <guava.version>25.1-jre</guava.version>
     <hamcrest.version>2.1</hamcrest.version>
     <jackson.version>2.10.2</jackson.version>
     <joda.version>2.10.5</joda.version>
-    <junit.version>4.13-beta-3</junit.version>
-    <libraries-bom.version>13.2.0</libraries-bom.version>
+    <junit.version>4.13.2</junit.version>
     <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
     <maven-exec-plugin.version>1.6.0</maven-exec-plugin.version>
     <maven-jar-plugin.version>3.0.2</maven-jar-plugin.version>
@@ -52,10 +49,21 @@
 
     <avro.version>1.10.0</avro.version>
     <json.version>20200518</json.version>
-    <google-http-client.version>1.38.0</google-http-client.version>
     <google-auto-service.version>1.0-rc7</google-auto-service.version>
 
   </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.apache.beam</groupId>
+        <artifactId>beam-sdks-java-google-cloud-platform-bom</artifactId>
+        <version>${beam.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <repositories>
     <repository>
@@ -170,7 +178,6 @@
         <dependency>
           <groupId>org.apache.beam</groupId>
           <artifactId>beam-runners-direct-java</artifactId>
-          <version>${beam.version}</version>
           <scope>runtime</scope>
         </dependency>
       </dependencies>
@@ -186,7 +193,6 @@
         <dependency>
           <groupId>org.apache.beam</groupId>
           <artifactId>beam-runners-portability-java</artifactId>
-          <version>${beam.version}</version>
           <scope>runtime</scope>
         </dependency>
       </dependencies>
@@ -199,7 +205,6 @@
         <dependency>
           <groupId>org.apache.beam</groupId>
           <artifactId>beam-runners-google-cloud-dataflow-java</artifactId>
-          <version>${beam.version}</version>
           <scope>runtime</scope>
         </dependency>
       </dependencies>
@@ -215,7 +220,6 @@
                of supported Flink versions and their artifact names:
                https://beam.apache.org/documentation/runners/flink/ -->
           <artifactId>${flink.artifact.name}</artifactId>
-          <version>${beam.version}</version>
           <scope>runtime</scope>
         </dependency>
       </dependencies>
@@ -232,14 +236,12 @@
         <dependency>
           <groupId>org.apache.beam</groupId>
           <artifactId>beam-runners-spark</artifactId>
-          <version>${beam.version}</version>
           <scope>runtime</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.beam/beam-sdks-java-io-hadoop-file-system -->
         <dependency>
           <groupId>org.apache.beam</groupId>
           <artifactId>beam-sdks-java-io-hadoop-file-system</artifactId>
-          <version>${beam.version}</version>
           <scope>runtime</scope>
         </dependency>
         <dependency>
@@ -264,7 +266,6 @@
         <dependency>
           <groupId>org.apache.beam</groupId>
           <artifactId>beam-sdks-java-io-google-cloud-platform</artifactId>
-          <version>${beam.version}</version>
           <exclusions>
             <exclusion>
               <groupId>io.grpc</groupId>
@@ -284,7 +285,6 @@
         <dependency>
           <groupId>org.apache.beam</groupId>
           <artifactId>beam-runners-samza</artifactId>
-          <version>${beam.version}</version>
           <scope>runtime</scope>
         </dependency>
       </dependencies>
@@ -321,7 +321,6 @@
         <dependency>
           <groupId>org.apache.beam</groupId>
           <artifactId>beam-runners-jet</artifactId>
-          <version>${beam.version}</version>
           <scope>runtime</scope>
         </dependency>
       </dependencies>
@@ -334,21 +333,18 @@
     <dependency>
       <groupId>org.apache.beam</groupId>
       <artifactId>beam-sdks-java-core</artifactId>
-      <version>${beam.version}</version>
     </dependency>
 
     <!-- Adds a dependency on the Beam Google Cloud Platform IO module. -->
     <dependency>
       <groupId>org.apache.beam</groupId>
       <artifactId>beam-sdks-java-io-google-cloud-platform</artifactId>
-      <version>${beam.version}</version>
     </dependency>
 
     <!-- Dependencies below this line are specific dependencies needed by the examples code. -->
     <dependency>
       <groupId>com.google.api-client</groupId>
       <artifactId>google-api-client</artifactId>
-      <version>${google-api-client.version}</version>
       <exclusions>
         <!-- Exclude an old version of guava that is being pulled
              in by a transitive dependency of google-api-client -->
@@ -376,7 +372,6 @@
     <dependency>
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client</artifactId>
-      <version>${google-http-client.version}</version>
       <exclusions>
         <!-- Exclude an old version of guava that is being pulled
              in by a transitive dependency of google-api-client -->
@@ -446,20 +441,17 @@
     <dependency>
       <groupId>org.apache.beam</groupId>
       <artifactId>beam-runners-direct-java</artifactId>
-      <version>${beam.version}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.apache.beam</groupId>
       <artifactId>beam-sdks-java-extensions-google-cloud-platform-core</artifactId>
-      <version>${beam.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.beam</groupId>
       <artifactId>beam-runners-google-cloud-dataflow-java</artifactId>
-      <version>${beam.version}</version>
       <!--      <scope>runtime</scope>-->
     </dependency>
 
@@ -468,14 +460,12 @@
     <dependency>
       <groupId>org.apache.beam</groupId>
       <artifactId>beam-sdks-java-extensions-sql</artifactId>
-      <version>${beam.version}</version>
     </dependency>
 
     <!-- Needed for Zeta SQL pipelines -->
     <dependency>
       <groupId>org.apache.beam</groupId>
       <artifactId>beam-sdks-java-extensions-sql-zetasql</artifactId>
-      <version>${beam.version}</version>
     </dependency>
 
 
@@ -509,7 +499,6 @@
     <dependency>
       <groupId>org.apache.beam</groupId>
       <artifactId>beam-sdks-java-io-jdbc</artifactId>
-      <version>${beam.version}</version>
     </dependency>
     <!-- https://mvnrepository.com/artifact/com.google.cloud.sql/mysql-socket-factory-connector-j-8 -->
     <dependency>


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/dataflow-cookbook/issues/1

Beam Bill of Materials (BOM) provides a set of compatible dependencies for a specific Beam version, it's arguably the safest way to pull dependencies and avoid conflicts / jar hells.

Some info provided at https://cloud.google.com/dataflow/docs/guides/common-errors#java-dependency-errors

