### PR TITLE
Add Python Kafka pipelines for read/write

### DIFF
--- a/Python/kafka/read_kafka.py
+++ b/Python/kafka/read_kafka.py
@@ -12,9 +12,11 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+# standard libraries
 import logging
-import apache_beam as beam
 
+# third party libraries
+import apache_beam as beam
 from apache_beam import Map
 from apache_beam.io.kafka import ReadFromKafka
 from apache_beam.options.pipeline_options import PipelineOptions
@@ -23,15 +25,17 @@ from apache_beam.options.pipeline_options import PipelineOptions
 class KafkaOptions(PipelineOptions):
     @classmethod
     def _add_argparse_args(cls, parser):
+        # Add a command line flag to be parsed along
+        # with other normal PipelineOptions
         parser.add_argument(
-            '--bootstrap_servers',
+            "--bootstrap_servers",
             default="localhost:9092",
-            help='Apache Kafka bootstrap servers'
+            help="Apache Kafka bootstrap servers"
         )
         parser.add_argument(
-            '--topic',
+            "--topic",
             default="your-topic",
-            help='Apache Kafka topic'
+            help="Apache Kafka topic"
         )
 
 
@@ -44,12 +48,17 @@ def run():
 
     with beam.Pipeline(options=options) as p:
 
-        output = (p | "Read from Kafka" >> ReadFromKafka(
-                        consumer_config={'bootstrap.servers': options.bootstrap_servers},
-                        topics=[options.topic],
-                        with_metadata=False
-                    )
-                    | "Log Data" >> Map(logging.info))
+        output = (
+            p
+            | "Read from Kafka" >> ReadFromKafka(
+                consumer_config={
+                    "bootstrap.servers": options.bootstrap_servers
+                },
+                topics=[options.topic],
+                with_metadata=False
+            )
+            | "Log Data" >> Map(logging.info)
+        )
 
 
 if __name__ == "__main__":

--- a/Python/kafka/read_kafka.py
+++ b/Python/kafka/read_kafka.py
@@ -1,0 +1,57 @@
+#  Copyright 2023 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import logging
+import apache_beam as beam
+
+from apache_beam import Map
+from apache_beam.io.kafka import ReadFromKafka
+from apache_beam.options.pipeline_options import PipelineOptions
+
+
+class KafkaOptions(PipelineOptions):
+    @classmethod
+    def _add_argparse_args(cls, parser):
+        parser.add_argument(
+            '--bootstrap_servers',
+            default="localhost:9092",
+            help='Apache Kafka bootstrap servers'
+        )
+        parser.add_argument(
+            '--topic',
+            default="your-topic",
+            help='Apache Kafka topic'
+        )
+
+
+def run():
+    """
+    This pipeline shows how to read from Apache Kafka.
+    """
+
+    options = KafkaOptions()
+
+    with beam.Pipeline(options=options) as p:
+
+        output = (p | "Read from Kafka" >> ReadFromKafka(
+                        consumer_config={'bootstrap.servers': options.bootstrap_servers},
+                        topics=[options.topic],
+                        with_metadata=False
+                    )
+                    | "Log Data" >> Map(logging.info))
+
+
+if __name__ == "__main__":
+    logging.getLogger().setLevel(logging.INFO)
+    run()

--- a/Python/kafka/write_kafka.py
+++ b/Python/kafka/write_kafka.py
@@ -65,8 +65,10 @@ def run():
                     "bootstrap.servers": options.bootstrap_servers
                 },
                 topic=options.topic,
-                key_serializer="org.apache.kafka.common.serialization.LongSerializer",
-                value_serializer="org.apache.kafka.common.serialization.StringSerializer"
+                key_serializer=
+                    "org.apache.kafka.common.serialization.LongSerializer",
+                value_serializer=
+                    "org.apache.kafka.common.serialization.StringSerializer"
             )
         )
 

--- a/Python/kafka/write_kafka.py
+++ b/Python/kafka/write_kafka.py
@@ -1,0 +1,68 @@
+#  Copyright 2023 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import logging
+import apache_beam as beam
+import typing
+
+from apache_beam import Map
+from apache_beam.io.kafka import WriteToKafka
+from apache_beam.options.pipeline_options import PipelineOptions
+
+
+class KafkaOptions(PipelineOptions):
+    @classmethod
+    def _add_argparse_args(cls, parser):
+        parser.add_argument(
+            '--bootstrap_servers',
+            default="localhost:9092",
+            help='Apache Kafka bootstrap server'
+        )
+        parser.add_argument(
+            '--topic',
+            default="your-topic",
+            help='Apache Kafka topic'
+        )
+
+
+def run():
+    """
+    This pipeline shows how to write to Apache Kafka.
+    """
+
+    options = KafkaOptions()
+
+    with beam.Pipeline(options=options) as p:
+
+        elements = [
+            (1, "Charles"),
+            (2, "Alice"),
+            (3, "Bob"),
+            (4, "Amanda"),
+            (5, "Alex"),
+            (6, "Eliza")
+        ]
+
+        output = (p | 'Create' >> beam.Create(elements)
+                    | beam.Map(lambda x: (x[0].to_bytes(2, 'big') , bytes(x[1], encoding=' utf-8')))
+                        .with_output_types(typing.Tuple[bytes, bytes])  # Kafka write transforms expects KVs.
+                    | "Write to Kafka" >> WriteToKafka(
+                        producer_config={'bootstrap.servers': options.bootstrap_servers},
+                        topic=options.topic
+                    ))
+
+
+if __name__ == "__main__":
+    logging.getLogger().setLevel(logging.INFO)
+    run()

--- a/Python/kafka/write_kafka.py
+++ b/Python/kafka/write_kafka.py
@@ -17,7 +17,7 @@ import logging
 
 # third party libraries
 import apache_beam as beam
-from apache_beam import Create, Map
+from apache_beam import Create
 from apache_beam.io.kafka import WriteToKafka
 from apache_beam.options.pipeline_options import PipelineOptions
 
@@ -65,10 +65,10 @@ def run():
                     "bootstrap.servers": options.bootstrap_servers
                 },
                 topic=options.topic,
-                key_serializer=
-                    "org.apache.kafka.common.serialization.LongSerializer",
-                value_serializer=
-                    "org.apache.kafka.common.serialization.StringSerializer"
+                key_serializer=("org.apache.kafka.common.serialization."
+                                "LongSerializer"),
+                value_serializer=("org.apache.kafka.common.serialization."
+                                  "StringSerializer")
             )
         )
 

--- a/Python/kafka/write_kafka.py
+++ b/Python/kafka/write_kafka.py
@@ -12,10 +12,12 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+# standard libraries
 import logging
-import apache_beam as beam
 
-from apache_beam import Map
+# third party libraries
+import apache_beam as beam
+from apache_beam import Create, Map
 from apache_beam.io.kafka import WriteToKafka
 from apache_beam.options.pipeline_options import PipelineOptions
 
@@ -23,15 +25,17 @@ from apache_beam.options.pipeline_options import PipelineOptions
 class KafkaOptions(PipelineOptions):
     @classmethod
     def _add_argparse_args(cls, parser):
+        # Add a command line flag to be parsed along
+        # with other normal PipelineOptions
         parser.add_argument(
-            '--bootstrap_servers',
+            "--bootstrap_servers",
             default="localhost:9092",
-            help='Apache Kafka bootstrap server'
+            help="Apache Kafka bootstrap server"
         )
         parser.add_argument(
-            '--topic',
+            "--topic",
             default="your-topic",
-            help='Apache Kafka topic'
+            help="Apache Kafka topic"
         )
 
 
@@ -53,13 +57,18 @@ def run():
             (6, "Eliza")
         ]
 
-        output = (p | 'Create' >> beam.Create(elements)
-                    | "Write to Kafka" >> WriteToKafka(
-                        producer_config={'bootstrap.servers': options.bootstrap_servers},
-                        topic=options.topic,
-                        key_serializer='org.apache.kafka.common.serialization.LongSerializer',
-                        value_serializer='org.apache.kafka.common.serialization.StringSerializer'
-                    ))
+        output = (
+            p
+            | "Create" >> Create(elements)
+            | "Write to Kafka" >> WriteToKafka(
+                producer_config={
+                    "bootstrap.servers": options.bootstrap_servers
+                },
+                topic=options.topic,
+                key_serializer="org.apache.kafka.common.serialization.LongSerializer",
+                value_serializer="org.apache.kafka.common.serialization.StringSerializer"
+            )
+        )
 
 
 if __name__ == "__main__":

--- a/Python/kafka/write_kafka.py
+++ b/Python/kafka/write_kafka.py
@@ -14,7 +14,6 @@
 
 import logging
 import apache_beam as beam
-import typing
 
 from apache_beam import Map
 from apache_beam.io.kafka import WriteToKafka
@@ -55,11 +54,11 @@ def run():
         ]
 
         output = (p | 'Create' >> beam.Create(elements)
-                    | beam.Map(lambda x: (x[0].to_bytes(2, 'big') , bytes(x[1], encoding=' utf-8')))
-                        .with_output_types(typing.Tuple[bytes, bytes])  # Kafka write transforms expects KVs.
                     | "Write to Kafka" >> WriteToKafka(
                         producer_config={'bootstrap.servers': options.bootstrap_servers},
-                        topic=options.topic
+                        topic=options.topic,
+                        key_serializer='org.apache.kafka.common.serialization.LongSerializer',
+                        value_serializer='org.apache.kafka.common.serialization.StringSerializer'
                     ))
 
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ The cookbook contains examples for Java, Python and Scala.
 
 - *bigquery*
 
+- *kafka*
+
 - *pubsub*
 
 - *windows*: example pipelines of the four windows


### PR DESCRIPTION
Pipelines added:

1. **Read from Apache Kafka**
IO: Kafka IO
SDK Language: Python
Run instruction:
- Start Apache Kafka
- Create Apache Kafka topic
- run `python read_kafka.py --runner="DataflowRunner" --project="your-project" --region="your-region" --bootstrap_servers="your-bootstrap-servers" --topic="your-topic"`

2. **Write to Apache Kafka**
IO: Kafka IO
SDK Language: Python
Run instruction:
- Start Apache Kafka
- Create Apache Kafka topic
- run `python write_kafka.py --runner="DataflowRunner" --project="your-project" --region="your-region" --bootstrap_servers="your-bootstrap-servers" --topic="your-topic"`
