### PR TITLE
Upgrade API versions to use 2.0.0

### DIFF
--- a/Java/pom.xml
+++ b/Java/pom.xml
@@ -29,7 +29,7 @@
   <properties>
     <beam.version>2.52.0</beam.version>
 
-    <bigquery.version>v2-rev20200719-1.30.10</bigquery.version>
+    <bigquery.version>v2-rev20231008-2.0.0</bigquery.version>
     <hamcrest.version>2.1</hamcrest.version>
     <jackson.version>2.10.2</jackson.version>
     <joda.version>2.10.5</joda.version>
@@ -39,7 +39,7 @@
     <maven-jar-plugin.version>3.0.2</maven-jar-plugin.version>
     <maven-shade-plugin.version>3.1.0</maven-shade-plugin.version>
     <mockito.version>3.0.0</mockito.version>
-    <pubsub.version>v1-rev20200713-1.30.10</pubsub.version>
+    <pubsub.version>v1-rev20231104-2.0.0</pubsub.version>
     <slf4j.version>1.7.30</slf4j.version>
     <spark.version>2.4.7</spark.version>
     <hadoop.version>2.10.1</hadoop.version>


### PR DESCRIPTION
google-api-client 1.30.x is incompatible with some other libraries introduced by Beam 2.52.0