### PR TITLE
Do not enable verbose SSL by default on Cookbook projects

### DIFF
--- a/Java/src/main/java/extra/JVMInitializer.java
+++ b/Java/src/main/java/extra/JVMInitializer.java
@@ -35,7 +35,13 @@ public class JVMInitializer {
         @Override
         public void onStartup() {
             LOG.info("Setting up Java VM Initializer");
-            System.setProperty("javax.net.debug", "ssl:verbose");
+
+            // Do not set verbose automatically
+            // System.setProperty("javax.net.debug", "ssl:verbose");
+
+            // Do not disable TLS verification automatically
+            // Security.setProperty("jdk.tls.disabledAlgorithms", "none");
+
         }
 
         @Override


### PR DESCRIPTION
It makes the logs extremely verbose (and costly)

![image](https://github.com/GoogleCloudPlatform/dataflow-cookbook/assets/3207647/7e55fb7d-6fdf-4243-b420-b96a7c18cbeb)
