### PR TITLE
Add Python TFRecord pipelines for read/write

### DIFF
--- a/Python/tfrecord/read_tfrecord.py
+++ b/Python/tfrecord/read_tfrecord.py
@@ -12,9 +12,11 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+# standard libraries
 import logging
-import apache_beam as beam
 
+# third party libraries
+import apache_beam as beam
 from apache_beam import Map
 from apache_beam.io.tfrecordio import ReadFromTFRecord
 from apache_beam.options.pipeline_options import PipelineOptions
@@ -23,10 +25,12 @@ from apache_beam.options.pipeline_options import PipelineOptions
 class TFRecordOptions(PipelineOptions):
     @classmethod
     def _add_argparse_args(cls, parser):
+        # Add a command line flag to be parsed along
+        # with other normal PipelineOptions
         parser.add_argument(
-            '--file_pattern',
+            "--file_pattern",
             default="your-file-pattern",
-            help='A file glob pattern to read TFRecords from.'
+            help="A file glob pattern to read TFRecords from."
         )
 
 
@@ -39,14 +43,23 @@ def run():
 
     with beam.Pipeline(options=options) as p:
 
-        output = (p | "Read from TFRecord" >> ReadFromTFRecord(
-                        file_pattern=options.file_pattern
-                    )
-                    | "Map from bytes" >> Map(map_from_bytes)
-                    | "Log Data" >> Map(logging.info))
+        output = (
+            p
+            | "Read from TFRecord" >> ReadFromTFRecord(
+                file_pattern=options.file_pattern
+            )
+            | "Map from bytes" >> Map(map_from_bytes)
+            | "Log Data" >> Map(logging.info)
+        )
 
 
 def map_from_bytes(element):
+    """
+    Deserializes the input bytes using pickle library and
+    returns the reconstructed object.
+    By default TFRecordIO transforms use `coders.BytesCoder()`.
+    """
+    # third party libraries
     import pickle
 
     return pickle.loads(element)

--- a/Python/tfrecord/read_tfrecord.py
+++ b/Python/tfrecord/read_tfrecord.py
@@ -1,0 +1,57 @@
+#  Copyright 2023 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import logging
+import apache_beam as beam
+
+from apache_beam import Map
+from apache_beam.io.tfrecordio import ReadFromTFRecord
+from apache_beam.options.pipeline_options import PipelineOptions
+
+
+class TFRecordOptions(PipelineOptions):
+    @classmethod
+    def _add_argparse_args(cls, parser):
+        parser.add_argument(
+            '--file_pattern',
+            default="your-file-pattern",
+            help='A file glob pattern to read TFRecords from.'
+        )
+
+
+def run():
+    """
+    This pipeline shows how to read from TFRecord format.
+    """
+
+    options = TFRecordOptions()
+
+    with beam.Pipeline(options=options) as p:
+
+        output = (p | "Read from TFRecord" >> ReadFromTFRecord(
+                        file_pattern=options.file_pattern
+                    )
+                    | "Map from bytes" >> Map(map_from_bytes)
+                    | "Log Data" >> Map(logging.info))
+
+
+def map_from_bytes(element):
+    import pickle
+
+    return pickle.loads(element)
+
+
+if __name__ == "__main__":
+    logging.getLogger().setLevel(logging.INFO)
+    run()

--- a/Python/tfrecord/write_tfrecord.py
+++ b/Python/tfrecord/write_tfrecord.py
@@ -1,0 +1,67 @@
+#  Copyright 2023 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import logging
+import apache_beam as beam
+
+from apache_beam import Create
+from apache_beam import Map
+from apache_beam.io.tfrecordio import WriteToTFRecord
+from apache_beam.options.pipeline_options import PipelineOptions
+
+
+class TFRecordOptions(PipelineOptions):
+    @classmethod
+    def _add_argparse_args(cls, parser):
+        parser.add_argument(
+            '--file_path_prefix',
+            default="your-file-path-prefix",
+            help='A file path prefix to write TFRecords files to.'
+        )
+
+
+def run():
+    """
+    This pipeline shows how to write to TFRecord format.
+    """
+
+    options = TFRecordOptions()
+
+    with beam.Pipeline(options=options) as p:
+
+        elements = [
+            (1, "Charles"),
+            (2, "Alice"),
+            (3, "Bob"),
+            (4, "Amanda"),
+            (5, "Alex"),
+            (6, "Eliza")
+        ]
+
+        output = (p | 'Create' >> Create(elements)
+                    | 'Map to Bytes' >> Map(map_to_bytes)
+                    | "Write to TFRecord" >> WriteToTFRecord(
+                        file_path_prefix=options.file_path_prefix
+                    ))
+
+
+def map_to_bytes(element):
+    import pickle
+
+    return pickle.dumps(element)
+
+
+if __name__ == "__main__":
+    logging.getLogger().setLevel(logging.INFO)
+    run()

--- a/Python/tfrecord/write_tfrecord.py
+++ b/Python/tfrecord/write_tfrecord.py
@@ -12,11 +12,12 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+# standard libraries
 import logging
-import apache_beam as beam
 
-from apache_beam import Create
-from apache_beam import Map
+# third party libraries
+import apache_beam as beam
+from apache_beam import Create, Map
 from apache_beam.io.tfrecordio import WriteToTFRecord
 from apache_beam.options.pipeline_options import PipelineOptions
 
@@ -24,10 +25,12 @@ from apache_beam.options.pipeline_options import PipelineOptions
 class TFRecordOptions(PipelineOptions):
     @classmethod
     def _add_argparse_args(cls, parser):
+        # Add a command line flag to be parsed along
+        # with other normal PipelineOptions
         parser.add_argument(
-            '--file_path_prefix',
+            "--file_path_prefix",
             default="your-file-path-prefix",
-            help='A file path prefix to write TFRecords files to.'
+            help="A file path prefix to write TFRecords files to."
         )
 
 
@@ -49,14 +52,23 @@ def run():
             (6, "Eliza")
         ]
 
-        output = (p | 'Create' >> Create(elements)
-                    | 'Map to Bytes' >> Map(map_to_bytes)
-                    | "Write to TFRecord" >> WriteToTFRecord(
-                        file_path_prefix=options.file_path_prefix
-                    ))
+        output = (
+            p
+            | "Create" >> Create(elements)
+            | "Map to Bytes" >> Map(map_to_bytes)
+            | "Write to TFRecord" >> WriteToTFRecord(
+                file_path_prefix=options.file_path_prefix
+            )
+        )
 
 
 def map_to_bytes(element):
+    """
+    Serializes the input element using pickle library and
+    returns the bytes representation.
+    By default TFRecordIO transforms use `coders.BytesCoder()`.
+    """
+    # third party libraries
     import pickle
 
     return pickle.dumps(element)

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ The cookbook contains examples for Java, Python and Scala.
 
 - *pubsub*
 
+- *tfrecord*
+
 - *windows*: example pipelines of the four windows
 
 - *testing_windows*: pipelines that, using the way to test windows, explain how


### PR DESCRIPTION
Pipelines added:

1. **Read from TFRecord**
IO: TFRecord IO
SDK Language: Python
Run instruction:
- Create set of .tfrecord files
- run `python read_tfrecord.py --runner="DataflowRunner" --project="your-project" --region="your-region" --file_pattern="your-file-pattern"`

2. **Write to TFRecord**
IO: TFRecord IO
SDK Language: Python
Run instruction:
- Create folder for .tfrecord files
- run `python write_tfrecord.py --runner="DataflowRunner" --project="your-project" --region="your-region" --file_path_prefix="your-file-path-prefix"`
