### PR TITLE
Add Python FileIO pipelines for read/write

### DIFF
--- a/Python/file/match_files.py
+++ b/Python/file/match_files.py
@@ -29,7 +29,7 @@ class FilesOptions(PipelineOptions):
         # with other normal PipelineOptions
         parser.add_argument(
             "--file_pattern",
-            default="your-file-pattern",
+            required=True,
             help="File pattern"
         )
 

--- a/Python/file/match_files.py
+++ b/Python/file/match_files.py
@@ -12,9 +12,11 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+# standard libraries
 import logging
-import apache_beam as beam
 
+# third party libraries
+import apache_beam as beam
 from apache_beam import Map
 from apache_beam.io.fileio import MatchFiles
 from apache_beam.options.pipeline_options import PipelineOptions
@@ -23,6 +25,8 @@ from apache_beam.options.pipeline_options import PipelineOptions
 class FilesOptions(PipelineOptions):
     @classmethod
     def _add_argparse_args(cls, parser):
+        # Add a command line flag to be parsed along
+        # with other normal PipelineOptions
         parser.add_argument(
             "--file_pattern",
             default="your-file-pattern",
@@ -32,17 +36,21 @@ class FilesOptions(PipelineOptions):
 
 def run():
     """
-    This pipeline shows how to read matching files in the form of ``FileMetadata`` objects.
+    This pipeline shows how to read matching files
+    in the form of ``FileMetadata`` objects.
     """
 
     options = FilesOptions()
 
     with beam.Pipeline(options=options) as p:
 
-        output = (p | "Match files" >> MatchFiles(
-                        file_pattern=options.file_pattern
-                    )
-                    | "Log Data" >> Map(logging.info))
+        output = (
+            p
+            | "Match files" >> MatchFiles(
+                file_pattern=options.file_pattern
+            )
+            | "Log Data" >> Map(logging.info)
+        )
 
 
 if __name__ == "__main__":

--- a/Python/file/match_files.py
+++ b/Python/file/match_files.py
@@ -1,0 +1,50 @@
+#  Copyright 2023 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import logging
+import apache_beam as beam
+
+from apache_beam import Map
+from apache_beam.io.fileio import MatchFiles
+from apache_beam.options.pipeline_options import PipelineOptions
+
+
+class FilesOptions(PipelineOptions):
+    @classmethod
+    def _add_argparse_args(cls, parser):
+        parser.add_argument(
+            "--file_pattern",
+            default="your-file-pattern",
+            help="File pattern"
+        )
+
+
+def run():
+    """
+    This pipeline shows how to read matching files in the form of ``FileMetadata`` objects.
+    """
+
+    options = FilesOptions()
+
+    with beam.Pipeline(options=options) as p:
+
+        output = (p | "Match files" >> MatchFiles(
+                        file_pattern=options.file_pattern
+                    )
+                    | "Log Data" >> Map(logging.info))
+
+
+if __name__ == "__main__":
+    logging.getLogger().setLevel(logging.INFO)
+    run()

--- a/Python/file/match_files_continuously.py
+++ b/Python/file/match_files_continuously.py
@@ -1,0 +1,51 @@
+#  Copyright 2023 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import logging
+import apache_beam as beam
+
+from apache_beam import Map
+from apache_beam.io.fileio import MatchContinuously
+from apache_beam.options.pipeline_options import PipelineOptions
+
+
+class FilesOptions(PipelineOptions):
+    @classmethod
+    def _add_argparse_args(cls, parser):
+        parser.add_argument(
+            "--file_pattern",
+            default="your-file-pattern",
+            help="File pattern"
+        )
+
+
+def run():
+    """
+    This pipeline shows how to read matching files in the form of ``FileMetadata`` objects continuously.
+    """
+
+    options = FilesOptions()
+
+    with beam.Pipeline(options=options) as p:
+
+        output = (p | "Match files" >> MatchContinuously(
+                        file_pattern=options.file_pattern,
+                        interval=10
+                    )
+                    | "Log Data" >> Map(logging.info))
+
+
+if __name__ == "__main__":
+    logging.getLogger().setLevel(logging.INFO)
+    run()

--- a/Python/file/match_files_continuously.py
+++ b/Python/file/match_files_continuously.py
@@ -12,9 +12,11 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+# standard libraries
 import logging
-import apache_beam as beam
 
+# third party libraries
+import apache_beam as beam
 from apache_beam import Map
 from apache_beam.io.fileio import MatchContinuously
 from apache_beam.options.pipeline_options import PipelineOptions
@@ -23,6 +25,8 @@ from apache_beam.options.pipeline_options import PipelineOptions
 class FilesOptions(PipelineOptions):
     @classmethod
     def _add_argparse_args(cls, parser):
+        # Add a command line flag to be parsed along
+        # with other normal PipelineOptions
         parser.add_argument(
             "--file_pattern",
             default="your-file-pattern",
@@ -32,18 +36,22 @@ class FilesOptions(PipelineOptions):
 
 def run():
     """
-    This pipeline shows how to read matching files in the form of ``FileMetadata`` objects continuously.
+    This pipeline shows how to read matching files
+    in the form of ``FileMetadata`` objects continuously.
     """
 
     options = FilesOptions()
 
     with beam.Pipeline(options=options) as p:
 
-        output = (p | "Match files" >> MatchContinuously(
-                        file_pattern=options.file_pattern,
-                        interval=10
-                    )
-                    | "Log Data" >> Map(logging.info))
+        output = (
+            p
+            | "Match files" >> MatchContinuously(
+                file_pattern=options.file_pattern,
+                interval=10
+            )
+            | "Log Data" >> Map(logging.info)
+        )
 
 
 if __name__ == "__main__":

--- a/Python/file/match_files_continuously.py
+++ b/Python/file/match_files_continuously.py
@@ -29,7 +29,7 @@ class FilesOptions(PipelineOptions):
         # with other normal PipelineOptions
         parser.add_argument(
             "--file_pattern",
-            default="your-file-pattern",
+            required=True,
             help="File pattern"
         )
 

--- a/Python/file/write_files.py
+++ b/Python/file/write_files.py
@@ -36,7 +36,7 @@ class FilesOptions(PipelineOptions):
 
 def run():
     """
-    This pipeline shows how to write write to a set of output files.
+    This pipeline shows how to write to a set of output files.
     """
 
     options = FilesOptions()

--- a/Python/file/write_files.py
+++ b/Python/file/write_files.py
@@ -29,7 +29,7 @@ class FilesOptions(PipelineOptions):
         # with other normal PipelineOptions
         parser.add_argument(
             "--path",
-            default="your-path",
+            required=True,
             help="The directory to write files into."
         )
 

--- a/Python/file/write_files.py
+++ b/Python/file/write_files.py
@@ -12,11 +12,12 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+# standard libraries
 import logging
-import apache_beam as beam
 
-from apache_beam import Create
-from apache_beam import Map
+# third party libraries
+import apache_beam as beam
+from apache_beam import Create, Map
 from apache_beam.io.fileio import WriteToFiles
 from apache_beam.options.pipeline_options import PipelineOptions
 
@@ -24,6 +25,8 @@ from apache_beam.options.pipeline_options import PipelineOptions
 class FilesOptions(PipelineOptions):
     @classmethod
     def _add_argparse_args(cls, parser):
+        # Add a command line flag to be parsed along
+        # with other normal PipelineOptions
         parser.add_argument(
             "--path",
             default="your-path",
@@ -48,14 +51,22 @@ def run():
             {'id': 6, 'name': 'Eliza'}
         ]
 
-        output = (p | "Create" >> Create(elements)
-                    | "Serialize" >> Map(map_to_json)
-                    | "Write to files" >> WriteToFiles(
-                        path=options.path
-                    ))
+        output = (
+            p
+            | "Create" >> Create(elements)
+            | "Serialize" >> Map(map_to_json)
+            | "Write to files" >> WriteToFiles(
+                path=options.path
+            )
+        )
 
 
 def map_to_json(element):
+    """
+    Converts a given input element into a JSON string.
+    """
+
+    # third party libraries
     import json
 
     return json.dumps(element)

--- a/Python/file/write_files.py
+++ b/Python/file/write_files.py
@@ -1,0 +1,66 @@
+#  Copyright 2023 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import logging
+import apache_beam as beam
+
+from apache_beam import Create
+from apache_beam import Map
+from apache_beam.io.fileio import WriteToFiles
+from apache_beam.options.pipeline_options import PipelineOptions
+
+
+class FilesOptions(PipelineOptions):
+    @classmethod
+    def _add_argparse_args(cls, parser):
+        parser.add_argument(
+            "--path",
+            default="your-path",
+            help="The directory to write files into."
+        )
+
+
+def run():
+    """
+    This pipeline shows how to write write to a set of output files.
+    """
+
+    options = FilesOptions()
+
+    with beam.Pipeline(options=options) as p:
+        elements = [
+            {'id': 1, 'name': 'Charles'},
+            {'id': 2, 'name': 'Alice'},
+            {'id': 3, 'name': 'Bob'},
+            {'id': 4, 'name': 'Amanda'},
+            {'id': 5, 'name': 'Alex'},
+            {'id': 6, 'name': 'Eliza'}
+        ]
+
+        output = (p | "Create" >> Create(elements)
+                    | "Serialize" >> Map(map_to_json)
+                    | "Write to files" >> WriteToFiles(
+                        path=options.path
+                    ))
+
+
+def map_to_json(element):
+    import json
+
+    return json.dumps(element)
+
+
+if __name__ == "__main__":
+    logging.getLogger().setLevel(logging.INFO)
+    run()

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ The cookbook contains examples for Java, Python and Scala.
 
 - *csv*
 
+- *file*
+
 - *gcs*
 
 - *json*
@@ -93,8 +95,6 @@ The cookbook contains examples for Java, Python and Scala.
 - *gcs*
 
 - *bigquery*
-
-- *file*
 
 - *pubsub*
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ The cookbook contains examples for Java, Python and Scala.
 
 - *bigquery*
 
+- *file*
+
 - *pubsub*
 
 - *windows*: example pipelines of the four windows


### PR DESCRIPTION
Pipelines added:

1. **Match files**
IO: File IO
SDK Language: Python
Run instruction:
- Create set of test files
- run `python match_files.py --runner="DataflowRunner" --project="your-project" --region="your-region" --file_pattern="your-file-pattern"`

2. **Match files continuously**
IO: File IO
SDK Language: Python
Run instruction:
- Create set of test files
- run `python match_files_continuously.py --runner="DataflowRunner" --project="your-project" --region="your-region" --file_pattern="your-file-pattern"`
- Create new files

3. **Write to files**
IO: File IO
SDK Language: Python
Run instruction:
- Create folder for test files
- run `python write_files.py --runner="DataflowRunner" --project="your-project" --region="your-region" --path="your-path"`
